### PR TITLE
Fix | Fixed Searching Deeply Nested Elements

### DIFF
--- a/src/XmlReader.php
+++ b/src/XmlReader.php
@@ -7,7 +7,6 @@ namespace Saloon\XmlWrangler;
 use Generator;
 use Throwable;
 use DOMElement;
-use LogicException;
 use Saloon\Http\Response;
 use VeeWee\Xml\Dom\Document;
 use InvalidArgumentException;
@@ -15,7 +14,6 @@ use VeeWee\Xml\Reader\Reader;
 use VeeWee\Xml\Reader\Matcher;
 use Saloon\XmlWrangler\Data\Element;
 use Psr\Http\Message\MessageInterface;
-use VeeWee\Xml\Reader\Node\NodeSequence;
 use function VeeWee\Xml\Encoding\xml_decode;
 use function VeeWee\Xml\Encoding\element_decode;
 use Saloon\XmlWrangler\Exceptions\XmlReaderException;
@@ -26,11 +24,6 @@ class XmlReader
      * XML Reader
      */
     protected Reader $reader;
-
-    /**
-     * Root element name
-     */
-    protected string $rootElementName;
 
     /**
      * Temporary File For Stream
@@ -52,8 +45,6 @@ class XmlReader
 
         $this->reader = $reader;
         $this->streamFile = $streamFile;
-
-        $this->loadRootElementName();
     }
 
     /**
@@ -192,12 +183,6 @@ class XmlReader
         try {
             $searchTerms = explode('.', $name);
 
-            // Remove the root element name because we search underneath it
-
-            if ($searchTerms[0] === $this->rootElementName) {
-                array_shift($searchTerms);
-            }
-
             $lastSearchTermIndex = array_key_last($searchTerms);
 
             // We'll start by creating a matcher for each search term that has been provided.
@@ -247,10 +232,7 @@ class XmlReader
             }
 
             $results = $this->reader->provide(
-                Matcher\nested(
-                    Matcher\document_element(),
-                    ...$matchers
-                ),
+                Matcher\nested(...$matchers),
             );
 
             // Now we'll create our own generator around the generator provided by the results.
@@ -433,24 +415,6 @@ class XmlReader
         }
 
         return [$key => $element];
-    }
-
-    /**
-     * Load the root element name of the document
-     */
-    private function loadRootElementName(): void
-    {
-        try {
-            $this->reader->provide(
-                function (NodeSequence $nodeSequence) {
-                    $this->rootElementName = $nodeSequence->current()->name();
-
-                    throw new LogicException;
-                }
-            )->current();
-        } catch (LogicException) {
-            //
-        }
     }
 
     /**

--- a/src/XmlReader.php
+++ b/src/XmlReader.php
@@ -246,14 +246,6 @@ class XmlReader
                 $matchers[$lastMatcherIndex] = Matcher\all($matchers[$lastMatcherIndex], ...$attributeMatchers);
             }
 
-            // If there is more than one matcher, then we should wrap the matchers in a sequence.
-            // This will mean that each matcher will only use the results from the previous
-            // matcher.
-
-            if (count($matchers) > 1) {
-                $matchers = [Matcher\sequence(...$matchers)];
-            }
-
             $results = $this->reader->provide(
                 Matcher\nested(
                     Matcher\document_element(),

--- a/tests/Feature/XmlReaderTest.php
+++ b/tests/Feature/XmlReaderTest.php
@@ -437,6 +437,14 @@ test('the root element name is discarded', function () {
     expect($reader->value('breakfast_menu.name.0')->sole())->toBe('Belgian Waffles');
 });
 
+test('can read deeply nested items', function () {
+    $reader = XmlReader::fromFile('tests/Fixtures/nested-breakfast-menu.xml');
+
+    expect($reader->value('food.ingredient')->get())->toEqual([
+        'Sugar', 'Berries', 'Bread', 'Egg',
+    ]);
+});
+
 test('can test large xml files', function () {
     $file = '/Users/samcarre/Documents/XML/psd7003.xml';
 

--- a/tests/Fixtures/nested-breakfast-menu.xml
+++ b/tests/Fixtures/nested-breakfast-menu.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<breakfast_menu name="Big G's Breakfasts">
+  <food soldOut="false" bestSeller="true">
+    <name>Berry-Berry Belgian Waffles</name>
+    <price>$8.95</price>
+    <description>Light Belgian waffles covered with an assortment of fresh berries and whipped cream</description>
+    <calories>900</calories>
+    <ingredients>
+      <ingredient>Sugar</ingredient>
+      <ingredient>Berries</ingredient>
+    </ingredients>
+  </food>
+  <food soldOut="true" bestSeller="false">
+    <name>French Toast</name>
+    <price>$4.50</price>
+    <description>Thick slices made from our homemade sourdough bread</description>
+    <calories>600</calories>
+    <ingredients>
+      <ingredient>Bread</ingredient>
+      <ingredient>Egg</ingredient>
+    </ingredients>
+  </food>
+  <food soldOut="false" bestSeller="false">
+    <name>Homestyle Breakfast</name>
+    <price>$6.95</price>
+    <description>Two eggs, bacon or sausage, toast, and our ever-popular hash browns</description>
+    <calories>950</calories>
+  </food>
+</breakfast_menu>


### PR DESCRIPTION
There was a bug where when searching for deeply nested children that the reader wouldn't recognise the search. I found the bug was caused by the sequence matcher, so I have removed this.

@veewee I don't quite understand the _why_ here, maybe I can get away with just using matcher `nested` as all my tests pass still.