### PR TITLE
Add xmlStandalone property to XmlWriter, includes a test and documentation

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -15,7 +15,7 @@ composer require saloonphp/xml-wrangler
 > Requires PHP 8.1+
 
 ## Reading XML
-Reading XML can be done by passing the XML string or file into the XML reader and using one of the many methods to search and find a specific element or value. 
+Reading XML can be done by passing the XML string or file into the XML reader and using one of the many methods to search and find a specific element or value.
 You can also convert every element into an easily traversable array if you prefer. If you need to access attributes on an element you can use
 the `Element` DTO which is a simple class to access the content and attributes. XML Wrangler provides methods to iterate through multiple elements while only
 keeping one element in memory at a time.
@@ -68,7 +68,7 @@ $reader->xpathValue('//food[@bestSeller="true"]/name')->get(); // ['Belgian Waff
 // Use getAttributes() to get the attributes on the elements
 $reader->element('food.0')->sole()->getAttributes(); // ['soldOut' => false, 'bestSeller' => true]
 
-// Use getContent() to get the contents of the elements 
+// Use getContent() to get the contents of the elements
 $reader->element('food.0')->sole()->getContent(); // ['name' => 'Belgian Waffles', 'price' => '$5.95', ...]
 ```
 
@@ -97,10 +97,10 @@ $xml = $writer->write('breakfast_menu', [
             'description' => 'Light Belgian waffles covered with strawberries and whipped cream',
             'calories' => '900',
         ],
-        
+
         // You can also use the Element class if you need to define elements with
         // namespaces or with attributes.
-        
+
         Element::make([
             'name' => 'Berry-Berry Belgian Waffles',
             'price' => '$8.95',
@@ -448,8 +448,8 @@ This will result in XML like this:
     </food>
 </breakfast_menu>
 ```
-#### Customising XML encoding and version
-The default XML encoding is `UTF-8` and the default version of XML is `1.0` if you would like to customise this you can with the `setXmlEncoding` and `setXmlVersion` methods on the writer.
+#### Customising XML encoding, version, and standalone
+The default XML encoding is `utf-8`, the default version of XML is `1.0`, and the default standalone is `null` (XML parsers interpret no standalone attribute the same as `false`). If you would like to customise this you can with the `setXmlEncoding`, `setXmlVersion`, and `setXmlStandalone` methods on the writer.
 ```php
 use Saloon\XmlWrangler\XmlWriter;
 
@@ -457,9 +457,11 @@ $writer = new XmlWriter();
 
 $writer->setXmlEncoding('ISO-8859-1');
 $writer->setXmlVersion('2.0');
+$writer->setXmlStandalone(true);
 
 // $writer->write(...);
 ```
+Which results in the XML declaration `<?xml version="2.0" encoding="ISO-8859-1" standalone="yes"?>`.
 #### Adding custom "Processing Instructions" to the XML
 You can add a custom "Processing Instruction" to the XML by using the `addProcessingInstruction` method.
 

--- a/src/XmlWriter.php
+++ b/src/XmlWriter.php
@@ -238,7 +238,7 @@ class XmlWriter
     /**
      * Set the XML encoding
      */
-    public function setXmlEncoding(string $xmlEncoding): XmlWriter
+    public function setXmlEncoding(string $xmlEncoding): static
     {
         $this->xmlEncoding = $xmlEncoding;
 
@@ -248,7 +248,7 @@ class XmlWriter
     /**
      * Set the XML version
      */
-    public function setXmlVersion(string $xmlVersion): XmlWriter
+    public function setXmlVersion(string $xmlVersion): static
     {
         $this->xmlVersion = $xmlVersion;
 
@@ -258,7 +258,7 @@ class XmlWriter
     /**
      * Set the XML standalone
      */
-    public function setXmlStandalone(bool $xmlStandalone): XmlWriter
+    public function setXmlStandalone(bool $xmlStandalone): static
     {
         $this->xmlStandalone = $xmlStandalone;
 

--- a/src/XmlWriter.php
+++ b/src/XmlWriter.php
@@ -24,6 +24,11 @@ class XmlWriter
     protected string $xmlVersion;
 
     /**
+     * XML standalone
+     */
+    protected bool $xmlStandalone;
+
+    /**
      * Additional processing instructions
      *
      * @var array<string, string>
@@ -33,18 +38,22 @@ class XmlWriter
     /**
      * Constructor
      */
-    public function __construct(string $xmlEncoding = 'utf-8', string $xmlVersion = '1.0')
+    public function __construct(string $xmlEncoding = 'utf-8', string $xmlVersion = '1.0', bool $xmlStandalone = null)
     {
         $this->xmlEncoding = $xmlEncoding;
         $this->xmlVersion = $xmlVersion;
+
+        if (! is_null($xmlStandalone)) {
+            $this->xmlStandalone = $xmlStandalone;
+        }
     }
 
     /**
      * Create an XML writer instance
      */
-    public static function make(string $xmlEncoding = 'utf-8', string $xmlVersion = '1.0'): static
+    public static function make(string $xmlEncoding = 'utf-8', string $xmlVersion = '1.0', bool $xmlStandalone = null): static
     {
-        return new static($xmlEncoding, $xmlVersion);
+        return new static($xmlEncoding, $xmlVersion, $xmlStandalone);
     }
 
     /**
@@ -85,7 +94,18 @@ class XmlWriter
             array_merge($rootElementContent, $content)
         );
 
-        $engine = new ArrayToXml($content, $rootElementBuilder, xmlEncoding: $this->xmlEncoding, xmlVersion: $this->xmlVersion);
+        $parameters = [
+            $content,
+            $rootElementBuilder,
+            'xmlEncoding' => $this->xmlEncoding,
+            'xmlVersion' => $this->xmlVersion
+        ];
+
+        if (isset($this->xmlStandalone)) {
+            $parameters['xmlStandalone'] = $this->xmlStandalone;
+        }
+
+        $engine = new ArrayToXml(...$parameters);
 
         // Processing instructions
 
@@ -231,6 +251,16 @@ class XmlWriter
     public function setXmlVersion(string $xmlVersion): XmlWriter
     {
         $this->xmlVersion = $xmlVersion;
+
+        return $this;
+    }
+
+    /**
+     * Set the XML standalone
+     */
+    public function setXmlStandalone(bool $xmlStandalone): XmlWriter
+    {
+        $this->xmlStandalone = $xmlStandalone;
 
         return $this;
     }

--- a/tests/Feature/XmlWriterTest.php
+++ b/tests/Feature/XmlWriterTest.php
@@ -42,6 +42,24 @@ XML
     );
 });
 
+test('you can set custom standalone on the writer', function () {
+    $writer = new XmlWriter;
+
+    $writer->setXmlStandalone(true);
+
+    $xml = $writer->write('root', ['a' => 'b']);
+
+    expect($xml)->toBe(
+        <<<XML
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<root>
+  <a>b</a>
+</root>
+
+XML
+    );
+});
+
 test('xml can be minified', function () {
     $writer = new XmlWriter;
 


### PR DESCRIPTION
Spatie's spatie/array-to-xml package exposes a parameter to set the XML standalone attribute in the declaration.

This pull request adds that to saloonphp/xml-wrangler. The implementation mirrors the existing API for XmlEncoding and XmlVersion.