### PR TITLE
Fix | Broken XPath Test

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "homepage": "https://github.com/saloonphp/xml-wrangler",
     "require": {
         "php": "^8.1",
-        "veewee/xml": "^2.11",
+        "veewee/xml": "^2.11.1",
         "spatie/array-to-xml": "^3.2",
         "ext-dom": "*"
     },

--- a/src/XmlReader.php
+++ b/src/XmlReader.php
@@ -8,7 +8,6 @@ use Generator;
 use Throwable;
 use DOMElement;
 use Saloon\Http\Response;
-use VeeWee\Xml\Dom\Xpath;
 use VeeWee\Xml\Dom\Document;
 use InvalidArgumentException;
 use VeeWee\Xml\Reader\Reader;

--- a/tests/Feature/XmlReaderTest.php
+++ b/tests/Feature/XmlReaderTest.php
@@ -499,7 +499,6 @@ XML
             'class' => 'Symfony\Component\DependencyInjection\ContainerInterface',
             'public' => 'true',
             'synthetic' => 'true',
-            'xmlns' => 'http://symfony.com/schema/dic/services',
         ])
     );
 


### PR DESCRIPTION
I noticed that since `veewee/xml` v2.11.1 one of the tests started to fail. @veewee I'm not quite sure why the `xmlns` is no longer appearing in the namespace list. It's not a big deal but just wanted to make you aware.

Also I tried to update the logic to use the traverse method directly on the `Document::fromXmlString()` but it didn't seem to work. 

All is well though! I'm really happy with how XML wrangler has turned out.