### PR TITLE
Feature | Add Generics For Query / LazyQuery

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "homepage": "https://github.com/saloonphp/xml-wrangler",
     "require": {
         "php": "^8.1",
-        "veewee/xml": "^2.11.1",
+        "veewee/xml": "^2.11.2",
         "spatie/array-to-xml": "^3.2",
         "ext-dom": "*"
     },

--- a/src/LazyQuery.php
+++ b/src/LazyQuery.php
@@ -7,6 +7,11 @@ namespace Saloon\XmlWrangler;
 use Generator;
 use Illuminate\Support\LazyCollection;
 
+/**
+ * @template TReturnType
+ *
+ * @extends \Saloon\XmlWrangler\Query<TReturnType>
+ */
 class LazyQuery extends Query
 {
     /**
@@ -30,7 +35,7 @@ class LazyQuery extends Query
      *
      * Requires illuminate/support
      *
-     * @return LazyCollection<int, mixed>
+     * @return LazyCollection<int, TReturnType>
      * @throws \Saloon\XmlWrangler\Exceptions\QueryAlreadyReadException
      */
     public function collectLazy(): LazyCollection

--- a/src/Query.php
+++ b/src/Query.php
@@ -10,6 +10,9 @@ use Saloon\XmlWrangler\Exceptions\MissingNodeException;
 use Saloon\XmlWrangler\Exceptions\QueryAlreadyReadException;
 use Saloon\XmlWrangler\Exceptions\MultipleNodesFoundException;
 
+/**
+ * @template TReturnType
+ */
 class Query
 {
     /**
@@ -39,7 +42,7 @@ class Query
     /**
      * Return the node as an array
      *
-     * @return array<string, mixed>
+     * @return array<string, TReturnType>
      * @throws \Saloon\XmlWrangler\Exceptions\QueryAlreadyReadException
      */
     public function get(): array
@@ -54,7 +57,7 @@ class Query
      *
      * Requires illuminate/support
      *
-     * @return Collection<string, mixed>
+     * @return Collection<string, TReturnType>
      * @throws \Saloon\XmlWrangler\Exceptions\QueryAlreadyReadException
      */
     public function collect(): Collection
@@ -65,6 +68,7 @@ class Query
     /**
      * Retrieve the first value in the node
      *
+     * @return TReturnType
      * @throws \Saloon\XmlWrangler\Exceptions\QueryAlreadyReadException
      */
     public function first(): mixed
@@ -81,6 +85,7 @@ class Query
     /**
      * Retrieve the first value in the node or fail
      *
+     * @return TReturnType
      * @throws \Saloon\XmlWrangler\Exceptions\MissingNodeException
      * @throws \Saloon\XmlWrangler\Exceptions\QueryAlreadyReadException
      */
@@ -94,7 +99,7 @@ class Query
      *
      * Throws an exception if none exist or more than one exists.
      *
-     * @return string|null
+     * @return ?TReturnType
      * @throws \Saloon\XmlWrangler\Exceptions\MissingNodeException
      * @throws \Saloon\XmlWrangler\Exceptions\MultipleNodesFoundException
      * @throws \Saloon\XmlWrangler\Exceptions\QueryAlreadyReadException

--- a/src/XmlReader.php
+++ b/src/XmlReader.php
@@ -186,6 +186,7 @@ class XmlReader
      * Find an element from the XML
      *
      * @param array<string, string> $withAttributes
+     * @return \Saloon\XmlWrangler\LazyQuery<Element>
      * @throws \Saloon\XmlWrangler\Exceptions\XmlReaderException
      * @throws \Throwable
      * @throws \VeeWee\Xml\Encoding\Exception\EncodingException
@@ -277,6 +278,7 @@ class XmlReader
     /**
      * Search for an element with xpath
      *
+     * @return \Saloon\XmlWrangler\Query<Element>
      * @throws \Throwable
      * @throws \VeeWee\Xml\Encoding\Exception\EncodingException
      */
@@ -340,6 +342,7 @@ class XmlReader
      * Find and retrieve value of element
      *
      * @param array<string, string> $attributes
+     * @return \Saloon\XmlWrangler\LazyQuery<mixed>
      * @throws \Saloon\XmlWrangler\Exceptions\XmlReaderException
      * @throws \Throwable
      */
@@ -353,6 +356,7 @@ class XmlReader
     /**
      * Find and retrieve value of element
      *
+     * @return \Saloon\XmlWrangler\Query<mixed>
      * @throws \Saloon\XmlWrangler\Exceptions\XmlReaderException
      * @throws \Throwable
      * @throws \VeeWee\Xml\Encoding\Exception\EncodingException

--- a/tests/Feature/XmlReaderTest.php
+++ b/tests/Feature/XmlReaderTest.php
@@ -445,7 +445,7 @@ test('can read deeply nested items', function () {
     ]);
 });
 
-test('root namespaces are removed from the element searches', function () {
+test('root namespaces are removed from xpath queries', function () {
     $reader = XmlReader::fromString(
         <<<XML
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd">
@@ -459,6 +459,8 @@ test('root namespaces are removed from the element searches', function () {
 </container>
 XML
     );
+
+    // Element should keep the xmlns
 
     $element = $reader->element('container.services.service', ['id' => 'service_container'])->sole();
 
@@ -499,6 +501,7 @@ XML
             'class' => 'Symfony\Component\DependencyInjection\ContainerInterface',
             'public' => 'true',
             'synthetic' => 'true',
+            'xmlns' => 'http://symfony.com/schema/dic/services'
         ])
     );
 
@@ -550,15 +553,3 @@ XML
 
     expect($mappedXpathTag)->toBe('1');
 });
-
-test('can test large xml files', function () {
-    $file = '/Users/samcarre/Documents/XML/psd7003.xml';
-
-    $reader = XmlReader::fromFile($file);
-
-    $values = $reader->value('refinfo')->lazy();
-
-    foreach ($values as $value) {
-        dd($value);
-    }
-})->skip();

--- a/tests/Feature/XmlReaderTest.php
+++ b/tests/Feature/XmlReaderTest.php
@@ -501,7 +501,7 @@ XML
             'class' => 'Symfony\Component\DependencyInjection\ContainerInterface',
             'public' => 'true',
             'synthetic' => 'true',
-            'xmlns' => 'http://symfony.com/schema/dic/services'
+            'xmlns' => 'http://symfony.com/schema/dic/services',
         ])
     );
 


### PR DESCRIPTION
This PR introduces generics for the `Query` and `LazyQuery` class which help IDE auto-completion when using any of the reader methods. Previously if you wrote something like this:

```php
$reader->element('breakfast_menu.food.0')->sole();
```

You wouldn't be able to see any of the methods from the `Element` class. Now you can.

![Screenshot 2023-11-12 at 22 48 10](https://github.com/saloonphp/xml-wrangler/assets/29132017/c9925dc1-9a0f-4d13-8c06-c5de8cf620ea)