### PR TITLE
Feature | Remove Namespaces From Reader

### DIFF
--- a/src/XmlReader.php
+++ b/src/XmlReader.php
@@ -500,7 +500,7 @@ class XmlReader
      *
      * @return $this
      */
-    public function withoutNamespaces(): static
+    public function removeNamespaces(): static
     {
         $this->includeNamespaces = false;
 

--- a/src/XmlReader.php
+++ b/src/XmlReader.php
@@ -45,6 +45,13 @@ class XmlReader
     protected array $xpathNamespaceMap = [];
 
     /**
+     * Include XML namespaces and prefixes
+     *
+     * @var bool
+     */
+    protected bool $includeNamespaces = true;
+
+    /**
      * Constructor
      *
      * @param resource $streamFile
@@ -399,7 +406,13 @@ class XmlReader
      */
     protected function parseXml(string $xml): Element|array
     {
-        $decoded = xml_decode($xml);
+        $xmlConfigurators = [];
+
+        if ($this->includeNamespaces === false) {
+            $xmlConfigurators[] = traverse(RemoveNamespaces::all());
+        }
+
+        $decoded = xml_decode($xml, ...$xmlConfigurators);
 
         $firstKey = array_key_first($decoded);
 
@@ -456,6 +469,18 @@ class XmlReader
     public function setXpathNamespaceMap(array $xpathNamespaceMap): XmlReader
     {
         $this->xpathNamespaceMap = $xpathNamespaceMap;
+
+        return $this;
+    }
+
+    /**
+     * Remove XML namespaces
+     *
+     * @return $this
+     */
+    public function withoutNamespaces(): static
+    {
+        $this->includeNamespaces = false;
 
         return $this;
     }

--- a/tests/Feature/XmlReaderTest.php
+++ b/tests/Feature/XmlReaderTest.php
@@ -554,7 +554,7 @@ XML
     expect($mappedXpathTag)->toBe('1');
 });
 
-test('can remove prefixes from xml', function () {
+test('can remove namespaces and prefixes from xml', function () {
     $reader = XmlReader::fromFile('tests/Fixtures/prefixed-breakfast-menu.xml');
 
     expect($reader->element('food.0')->first())->toBeNull();
@@ -574,9 +574,9 @@ test('can remove prefixes from xml', function () {
             ])
     );
 
-    // Now we'll remove the namespace
+    // Now we'll remove the namespaces
 
-    $reader->withoutNamespaces();
+    $reader->removeNamespaces();
 
     expect($reader->element('bkfst:food.0')->first())->toBeNull();
 

--- a/tests/Feature/XmlReaderTest.php
+++ b/tests/Feature/XmlReaderTest.php
@@ -616,3 +616,14 @@ test('can remove namespaces and prefixes from xml', function () {
 
     expect($unprefixedNodes)->toBe(20);
 });
+
+test('cannot use an xpath namespace map without namespaces', function () {
+    $reader = XmlReader::fromFile('tests/Fixtures/prefixed-breakfast-menu.xml');
+
+    $reader->removeNamespaces();
+    $reader->setXpathNamespaceMap([
+        'bkfast' => 'http://breakfast.test/example/doesnt-exist',
+    ]);
+
+    $reader->xpathValue('//food[1]/name')->sole();
+})->throws(XmlReaderException::class, 'XPath namespace map cannot be used when namespaces are removed.');

--- a/tests/Feature/XmlReaderTest.php
+++ b/tests/Feature/XmlReaderTest.php
@@ -553,3 +553,11 @@ XML
 
     expect($mappedXpathTag)->toBe('1');
 });
+
+test('can remove prefixes from xml', function () {
+    $reader = XmlReader::fromFile('tests/Fixtures/prefixed-breakfast-menu.xml');
+
+    $reader->withoutNamespaces();
+
+    dd($reader->element('food')->get());
+});

--- a/tests/Fixtures/prefixed-breakfast-menu.xml
+++ b/tests/Fixtures/prefixed-breakfast-menu.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<bkfst:breakfast_menu name="Big G's Breakfasts" xmlns:bkfst="http://breakfast.test/example/doesnt-exist">
+  <bkfst:food soldOut="false" bestSeller="true">
+    <bkfst:name>Belgian Waffles</bkfst:name>
+    <bkfst:price>$5.95</bkfst:price>
+    <bkfst:description>Two of our famous Belgian Waffles with plenty of real maple syrup</bkfst:description>
+    <bkfst:calories>650</bkfst:calories>
+  </bkfst:food>
+  <bkfst:food soldOut="false" bestSeller="false">
+    <bkfst:name>Strawberry Belgian Waffles</bkfst:name>
+    <bkfst:price>$7.95</bkfst:price>
+    <bkfst:description>Light Belgian waffles covered with strawberries and whipped cream</bkfst:description>
+    <bkfst:calories>900</bkfst:calories>
+  </bkfst:food>
+  <bkfst:food soldOut="false" bestSeller="true">
+    <bkfst:name>Berry-Berry Belgian Waffles</bkfst:name>
+    <bkfst:price>$8.95</bkfst:price>
+    <bkfst:description>Light Belgian waffles covered with an assortment of fresh berries and whipped cream</bkfst:description>
+    <bkfst:calories>900</bkfst:calories>
+  </bkfst:food>
+  <bkfst:food soldOut="true" bestSeller="false">
+    <bkfst:name>French Toast</bkfst:name>
+    <bkfst:price>$4.50</bkfst:price>
+    <bkfst:description>Thick slices made from our homemade sourdough bread</bkfst:description>
+    <bkfst:calories>600</bkfst:calories>
+  </bkfst:food>
+  <bkfst:food soldOut="false" bestSeller="false">
+    <bkfst:name>Homestyle Breakfast</bkfst:name>
+    <bkfst:price>$6.95</bkfst:price>
+    <bkfst:description>Two eggs, bacon or sausage, toast, and our ever-popular hash browns</bkfst:description>
+    <bkfst:calories>950</bkfst:calories>
+  </bkfst:food>
+</bkfst:breakfast_menu>


### PR DESCRIPTION
This PR introduces the ability to remove namespaces from the XML reader in a memory-efficient way. The namespaces are not removed from the reader before reading, but the matcher changes if the user wants to discard namespaces. After that, the XML decoding passes in an XML configurator which removes the namespaces and element prefixes from the final searched XML.

I have also removed the namespaces from the XPath methods by using a different XPath configurator rule.