### PR TITLE
Upgrade | PHP 8.3 & `veewee/xml` v3.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 # Caches, externally stored stuff, etc
 .php-cs-fixer.cache
 .phpunit.result.cache
+.phpunit.cache
 
 # environments/configs
 phpstan.neon

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "homepage": "https://github.com/saloonphp/xml-wrangler",
     "require": {
         "php": "^8.1",
-        "veewee/xml": "^2.11.2",
+        "veewee/xml": "^3.1.0",
         "spatie/array-to-xml": "^3.2",
         "ext-dom": "*"
     },

--- a/src/XmlReader.php
+++ b/src/XmlReader.php
@@ -12,6 +12,7 @@ use VeeWee\Xml\Dom\Document;
 use InvalidArgumentException;
 use VeeWee\Xml\Reader\Reader;
 use VeeWee\Xml\Reader\Matcher;
+use VeeWee\Xml\Reader\MatchingNode;
 use Saloon\XmlWrangler\Data\Element;
 use Psr\Http\Message\MessageInterface;
 use function VeeWee\Xml\Encoding\xml_decode;
@@ -189,7 +190,7 @@ class XmlReader
 
             $results = function () use ($results): Generator {
                 foreach ($results as $result) {
-                    yield from $this->parseXml($result);
+                    yield from $this->parseXml($result->xml());
                 }
             };
 
@@ -288,7 +289,7 @@ class XmlReader
                         continue;
                     }
 
-                    $element = $this->parseXml($result);
+                    $element = $this->parseXml($result->xml());
 
                     yield $element[array_key_first($element)];
                 }
@@ -328,9 +329,12 @@ class XmlReader
             if (empty($namespaceMap)) {
                 $namespaceFilter = $keepNamespaces ? RemoveNamespaces::unprefixed() : RemoveNamespaces::all();
 
-                $xml = Document::fromXmlString($xml, traverse($namespaceFilter))->toXmlString();
+                $xml = Document::fromXmlString($xml->xml(), traverse($namespaceFilter))->toXmlString();
             } else {
                 $xpathConfigurators[] = namespaces($namespaceMap);
+
+                // Make $xml from MatchingNode into a string
+                $xml = $xml->xml();
             }
 
             $xpath = Document::fromXmlString($xml)->xpath(...$xpathConfigurators);


### PR DESCRIPTION
@Sammyjo20 I'm a big fan of Saloon and this XML Wrangler. 🤠

I'm going through the process of updating my apps to 8.3, and when I noticed this didn't pass tests on 8.3, I delved a bit deeper. I have upgraded `veewee` to use the new version that supports 8.3 and amended your code to cope with their breaking change. 

All your tests pass.  Lines 335-337 in XmlReader.php are a bit messy on the `else` statement, but I couldn't easily find a cleaner way to do it. 

(Documentation of @veewee's breaking change is here: https://github.com/veewee/xml/releases/tag/3.0.0)