### PR TITLE
Fix | docblock return type for `Query::first()` and `Query::sole()`

### DIFF
--- a/src/Query.php
+++ b/src/Query.php
@@ -68,7 +68,7 @@ class Query
     /**
      * Retrieve the first value in the node
      *
-     * @return TReturnType
+     * @return ?TReturnType
      * @throws \Saloon\XmlWrangler\Exceptions\QueryAlreadyReadException
      */
     public function first(): mixed
@@ -99,7 +99,7 @@ class Query
      *
      * Throws an exception if none exist or more than one exists.
      *
-     * @return ?TReturnType
+     * @return TReturnType
      * @throws \Saloon\XmlWrangler\Exceptions\MissingNodeException
      * @throws \Saloon\XmlWrangler\Exceptions\MultipleNodesFoundException
      * @throws \Saloon\XmlWrangler\Exceptions\QueryAlreadyReadException


### PR DESCRIPTION
I am getting PHPStan errors because the docblock for `Query::first()` is incorrect, it can return `null`.

Also noticed that the docblock for `Query::sole()` has the opposite issue. `::sole()` never returns `null`, because it throws an exception when `null`