### PR TITLE
Add explicit nullable types for PHP 8.4 support

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.3'
+          php-version: '8.4'
           coverage: none
 
       - name: Install composer dependencies

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ ubuntu-latest, windows-latest ]
-        php: [ 8.1, 8.2, 8.3 ]
+        php: [ 8.1, 8.2, 8.3, 8.4 ]
         stability: [ prefer-lowest, prefer-stable ]
 
     name: P${{ matrix.php }} - ${{ matrix.stability }} - ${{ matrix.os }}

--- a/src/Data/CDATA.php
+++ b/src/Data/CDATA.php
@@ -16,7 +16,7 @@ class CDATA
      *
      * Base XML Element DTO
      */
-    public function __construct(string $content = null)
+    public function __construct(?string $content = null)
     {
         $this->setContent($content);
     }
@@ -24,7 +24,7 @@ class CDATA
     /**
      * Create an element instance
      */
-    public static function make(string $content = null): static
+    public static function make(?string $content = null): static
     {
         return new static($content);
     }

--- a/src/XmlWriter.php
+++ b/src/XmlWriter.php
@@ -38,7 +38,7 @@ class XmlWriter
     /**
      * Constructor
      */
-    public function __construct(string $xmlEncoding = 'utf-8', string $xmlVersion = '1.0', bool $xmlStandalone = null)
+    public function __construct(string $xmlEncoding = 'utf-8', string $xmlVersion = '1.0', ?bool $xmlStandalone = null)
     {
         $this->xmlEncoding = $xmlEncoding;
         $this->xmlVersion = $xmlVersion;
@@ -51,7 +51,7 @@ class XmlWriter
     /**
      * Create an XML writer instance
      */
-    public static function make(string $xmlEncoding = 'utf-8', string $xmlVersion = '1.0', bool $xmlStandalone = null): static
+    public static function make(string $xmlEncoding = 'utf-8', string $xmlVersion = '1.0', ?bool $xmlStandalone = null): static
     {
         return new static($xmlEncoding, $xmlVersion, $xmlStandalone);
     }


### PR DESCRIPTION
This update adds explicit nullable types to method signatures to ensure compatibility with PHP 8.4, as implicit nullability is deprecated.

Also updated the workflow to run tests against 8.4 and execute PHPStan on 8.4