### PR TITLE
Bump veewee/xml version to support PHP 8.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "homepage": "https://github.com/saloonphp/xml-wrangler",
     "require": {
         "php": "^8.2",
-        "veewee/xml": "^3.1.0",
+        "veewee/xml": "^3.3.0",
         "spatie/array-to-xml": "^3.2",
         "ext-dom": "*"
     },


### PR DESCRIPTION
PHP 8.5 does not seem to be supported yet.

Bumping the version should allow support for it.

See [spec complaince of veewee/xml](https://github.com/veewee/xml?tab=readme-ov-file#spec-compliance)

<img width="988" height="437" alt="image" src="https://github.com/user-attachments/assets/136a782a-0d5e-4dd4-8531-27c4729e5ec2" />
